### PR TITLE
Filtering a Map based on string key length

### DIFF
--- a/library/src/main/kotlin/com/michaelceley/extensions/MapExtensions.kt
+++ b/library/src/main/kotlin/com/michaelceley/extensions/MapExtensions.kt
@@ -1,0 +1,32 @@
+package com.michaelceley.extensions
+
+/**
+ * Transforms a map with string keys so that all keys are less than
+ * or equal to the specified length. Entries can either be removed from
+ * the map if their key is too long or the key can be truncated.
+ *
+ * @param keyLength The max length of the entry key.
+ * @param truncate Whether or not keys should be truncated. If not truncated,
+ *  then entries with keys that exceed the keyLength will be removed.
+ * @return The filtered [Map].
+ */
+fun Map<String, *>.filterKeyLength(
+    keyLength: Int,
+    truncate: Boolean = false
+) : Map<String, *> {
+    return if(truncate) {
+        // If truncating, map the keys to their truncated values.
+        mapKeys {
+            if(it.key.length > keyLength) {
+                it.key.utf16TruncateLength(keyLength).first
+            } else {
+                it.key
+            }
+        }
+    } else {
+        // If not truncating, filter out all entries with keys exceeding keyLength.
+        filterKeys {
+            it.length <= keyLength
+        }
+    }
+}

--- a/library/src/main/kotlin/com/michaelceley/extensions/MapExtensions.kt
+++ b/library/src/main/kotlin/com/michaelceley/extensions/MapExtensions.kt
@@ -5,6 +5,8 @@ package com.michaelceley.extensions
  * or equal to the specified length. Entries can either be removed from
  * the map if their key is too long or the key can be truncated.
  *
+ * WARNING: Truncating keys can cause key collisions and dropped values.
+ *
  * @param keyLength The max length of the entry key.
  * @param truncate Whether or not keys should be truncated. If not truncated,
  *  then entries with keys that exceed the keyLength will be removed.

--- a/library/src/test/kotlin/com/michaelceley/extensions/MapExtensionTests.kt
+++ b/library/src/test/kotlin/com/michaelceley/extensions/MapExtensionTests.kt
@@ -1,0 +1,85 @@
+package com.michaelceley.extensions
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MapExtensionTests {
+
+    @Test
+    fun `filterKeyLength can be called on empty map without exception`() {
+        val expectedValue = mapOf<String, Any>()
+        val actualValue = expectedValue.filterKeyLength(10)
+
+        assertEquals(expectedValue, actualValue)
+    }
+
+    @Test
+    fun `Keys of max length are not dropped when not truncating`() {
+        val expectedValue = mapOf(
+            "1234567890" to ""
+        )
+        val actualValue = expectedValue.filterKeyLength(10, false)
+    }
+
+    @Test
+    fun `Keys of max length are not altered when truncating`() {
+        val expectedValue = mapOf(
+            "1234567890" to ""
+        )
+        val actualValue = expectedValue.filterKeyLength(10, true)
+    }
+
+    @Test
+    fun `Keys exceeding max length are dropped when not truncating`() {
+        val expectedValue = mapOf(
+            "short key" to "",
+            "shorter" to ""
+        )
+        val actualValue = mapOf(
+            "this is a long key" to "",
+            "short key" to "",
+            "this is a longer key" to "",
+            "shorter" to ""
+        ).filterKeyLength(10, false)
+
+        assertEquals(expectedValue, actualValue)
+    }
+
+    @Test
+    fun `Keys exceeding max length are truncated`() {
+        val expectedValue = mapOf(
+            "long key o" to "",
+            "short key" to "",
+            "this is a " to "",
+            "shorter" to ""
+        )
+        val actualValue = mapOf(
+            "long key of length exceeding 10" to "",
+            "short key" to "",
+            "this is a longer key" to "",
+            "shorter" to ""
+        ).filterKeyLength(10, true)
+
+        assertEquals(expectedValue, actualValue)
+        assertEquals(4, actualValue.size)
+    }
+
+    @Test
+    fun `Keys exceeding max length are truncated with colliding keys overwritten`() {
+        val expectedValue = mapOf(
+            "short key" to "",
+            "this is a " to "overwritten value",
+            "shorter" to ""
+        )
+        val actualValue = mapOf(
+            "this is a long key" to "dropped value",
+            "short key" to "",
+            "this is a longer key" to "overwritten value",
+            "shorter" to ""
+        ).filterKeyLength(10, true)
+
+        assertEquals(expectedValue, actualValue)
+        assertEquals(3, actualValue.size)
+        assertEquals("overwritten value", actualValue["this is a "])
+    }
+}

--- a/library/src/test/kotlin/com/michaelceley/extensions/StringExtensionTests.kt
+++ b/library/src/test/kotlin/com/michaelceley/extensions/StringExtensionTests.kt
@@ -5,8 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-
-class ExtensionTest {
+class StringExtensionTests {
 
     @Test
     fun testTruncateDoesNotChangeValueIfLengthIsMax() {


### PR DESCRIPTION
Adds an extension to `Map<String, *>` to filter the map based on the length of the key. Entries with keys exceeding max length can either be dropped from the map or have their keys truncated to the max length. Truncating keys can cause key collisions, leading to dropped values.

Implements #2 